### PR TITLE
feat(core): add Memory dataclass and related models

### DIFF
--- a/src/cognitive_memory/core/__init__.py
+++ b/src/cognitive_memory/core/__init__.py
@@ -1,1 +1,25 @@
 """Core data models, configuration, and exceptions."""
+
+from cognitive_memory.core.memory import (
+    Entity,
+    Fact,
+    Memory,
+    MemorySource,
+    MemoryType,
+    Procedure,
+    Relationship,
+    ScoredMemory,
+    ToolPattern,
+)
+
+__all__ = [
+    "Entity",
+    "Fact",
+    "Memory",
+    "MemorySource",
+    "MemoryType",
+    "Procedure",
+    "Relationship",
+    "ScoredMemory",
+    "ToolPattern",
+]

--- a/src/cognitive_memory/core/memory.py
+++ b/src/cognitive_memory/core/memory.py
@@ -1,0 +1,280 @@
+"""Core memory data models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+from uuid import uuid4
+
+
+def _utcnow() -> datetime:
+    """Return current UTC time."""
+    return datetime.now(timezone.utc)
+
+
+def _uuid() -> str:
+    """Generate a new UUID string."""
+    return str(uuid4())
+
+
+class MemoryType(str, Enum):
+    """Type of memory tier."""
+
+    EPISODIC = "episodic"
+    SEMANTIC = "semantic"
+    PROCEDURAL = "procedural"
+
+
+class MemorySource(str, Enum):
+    """Source of the memory."""
+
+    CONVERSATION = "conversation"
+    TOOL_RESULT = "tool_result"
+    OBSERVATION = "observation"
+    CONSOLIDATION = "consolidation"
+    EXTERNAL = "external"
+    USER_EXPLICIT = "user_explicit"
+
+
+@dataclass
+class Memory:
+    """
+    Core memory unit.
+
+    Represents a single memory with decay, importance, and relationship metadata.
+
+    Attributes:
+        id: Unique identifier for the memory.
+        memory_type: Type of memory (episodic, semantic, procedural).
+        content: The actual content/text of the memory.
+        embedding: Vector embedding of the content.
+        metadata: Additional key-value metadata.
+        created_at: When the memory was created.
+        last_accessed_at: When the memory was last retrieved.
+        access_count: Number of times the memory has been retrieved.
+        strength: Current strength after decay (computed).
+        initial_strength: Strength at creation, boosted by rehearsal.
+        importance: Computed importance score (0-1).
+        emotional_valence: Emotional tone (-1 negative to 1 positive).
+        surprise_score: How unexpected the information was (0-1).
+        source: Where the memory came from.
+        source_id: Reference to source (conversation_id, etc.).
+        agent_id: ID of the agent that owns this memory.
+        user_id: ID of the user associated with this memory.
+        entities: Named entities extracted from content.
+        topics: Topics/themes extracted from content.
+        related_memory_ids: IDs of related memories.
+        parent_memory_id: ID of parent memory if derived.
+        superseded_by_id: ID of memory that replaced this one.
+        is_pinned: If True, memory never decays.
+        is_archived: If True, memory is soft-deleted.
+        is_consolidated: If True, memory has been processed by consolidation.
+    """
+
+    id: str = field(default_factory=_uuid)
+    memory_type: MemoryType = MemoryType.EPISODIC
+    content: str = ""
+    embedding: list[float] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=_utcnow)
+    last_accessed_at: datetime = field(default_factory=_utcnow)
+    access_count: int = 0
+    strength: float = 1.0
+    initial_strength: float = 1.0
+    importance: float = 0.5
+    emotional_valence: float = 0.0
+    surprise_score: float = 0.0
+    source: MemorySource = MemorySource.CONVERSATION
+    source_id: str | None = None
+    agent_id: str | None = None
+    user_id: str | None = None
+    entities: list[str] = field(default_factory=list)
+    topics: list[str] = field(default_factory=list)
+    related_memory_ids: list[str] = field(default_factory=list)
+    parent_memory_id: str | None = None
+    superseded_by_id: str | None = None
+    is_pinned: bool = False
+    is_archived: bool = False
+    is_consolidated: bool = False
+
+
+@dataclass
+class ScoredMemory:
+    """
+    Memory with retrieval scores.
+
+    Returned by the retrieval engine with scoring breakdown.
+
+    Attributes:
+        memory: The underlying memory object.
+        similarity_score: Cosine similarity to query (0-1).
+        strength_score: Current decay-adjusted strength (0-1).
+        importance_score: Importance factor (0-1).
+        recency_score: How recently accessed (0-1).
+        final_score: Combined weighted score used for ranking.
+    """
+
+    memory: Memory
+    similarity_score: float = 0.0
+    strength_score: float = 0.0
+    importance_score: float = 0.0
+    recency_score: float = 0.0
+    final_score: float = 0.0
+
+
+@dataclass
+class Fact:
+    """
+    Semantic memory unit - a single fact.
+
+    Represents a subject-predicate-object triple with confidence.
+    Stored in the knowledge graph.
+
+    Attributes:
+        id: Unique identifier.
+        subject: The subject entity of the fact.
+        predicate: The relationship/predicate.
+        object: The object entity of the fact.
+        confidence: Confidence score (0-1).
+        source_memory_ids: IDs of episodic memories this was extracted from.
+        created_at: When the fact was created.
+        last_verified_at: When the fact was last confirmed.
+        verification_count: Number of times the fact was verified.
+        contradicted_by: IDs of facts that contradict this one.
+    """
+
+    id: str = field(default_factory=_uuid)
+    subject: str = ""
+    predicate: str = ""
+    object: str = ""
+    confidence: float = 1.0
+    source_memory_ids: list[str] = field(default_factory=list)
+    created_at: datetime = field(default_factory=_utcnow)
+    last_verified_at: datetime = field(default_factory=_utcnow)
+    verification_count: int = 1
+    contradicted_by: list[str] = field(default_factory=list)
+
+    def as_triple(self) -> str:
+        """Return the fact as a readable triple string."""
+        return f"{self.subject} {self.predicate} {self.object}"
+
+
+@dataclass
+class Entity:
+    """
+    Named entity in semantic memory.
+
+    Represents a person, organization, concept, or other named entity.
+
+    Attributes:
+        id: Unique identifier.
+        name: Canonical name of the entity.
+        entity_type: Type (person, organization, concept, location, etc.).
+        aliases: Alternative names for the entity.
+        attributes: Key-value attributes of the entity.
+        first_seen: When the entity was first mentioned.
+        last_seen: When the entity was most recently mentioned.
+        mention_count: Total number of mentions.
+    """
+
+    id: str = field(default_factory=_uuid)
+    name: str = ""
+    entity_type: str = ""
+    aliases: list[str] = field(default_factory=list)
+    attributes: dict[str, Any] = field(default_factory=dict)
+    first_seen: datetime = field(default_factory=_utcnow)
+    last_seen: datetime = field(default_factory=_utcnow)
+    mention_count: int = 1
+
+
+@dataclass
+class Relationship:
+    """
+    Relationship between entities in the knowledge graph.
+
+    Attributes:
+        id: Unique identifier.
+        source_entity_id: ID of the source entity.
+        target_entity_id: ID of the target entity.
+        relationship_type: Type of relationship.
+        properties: Additional properties of the relationship.
+        confidence: Confidence score (0-1).
+        source_memory_ids: IDs of memories this was extracted from.
+    """
+
+    id: str = field(default_factory=_uuid)
+    source_entity_id: str = ""
+    target_entity_id: str = ""
+    relationship_type: str = ""
+    properties: dict[str, Any] = field(default_factory=dict)
+    confidence: float = 1.0
+    source_memory_ids: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Procedure:
+    """
+    Procedural memory unit.
+
+    Represents a learned procedure, skill, or pattern.
+    Does not decay - only explicit updates/deletions.
+
+    Attributes:
+        id: Unique identifier.
+        name: Name of the procedure.
+        description: What the procedure does.
+        steps: Ordered list of steps.
+        preconditions: Conditions that must be true before execution.
+        postconditions: Expected outcomes after execution.
+        success_count: Number of successful executions.
+        failure_count: Number of failed executions.
+        last_used: When the procedure was last used.
+    """
+
+    id: str = field(default_factory=_uuid)
+    name: str = ""
+    description: str = ""
+    steps: list[str] = field(default_factory=list)
+    preconditions: list[str] = field(default_factory=list)
+    postconditions: list[str] = field(default_factory=list)
+    success_count: int = 0
+    failure_count: int = 0
+    last_used: datetime | None = None
+
+    @property
+    def success_rate(self) -> float:
+        """Calculate the success rate of this procedure."""
+        total = self.success_count + self.failure_count
+        if total == 0:
+            return 0.0
+        return self.success_count / total
+
+
+@dataclass
+class ToolPattern:
+    """
+    Learned tool usage pattern.
+
+    Tracks how tools are used and their success rates.
+
+    Attributes:
+        id: Unique identifier.
+        tool_name: Name of the tool.
+        input_pattern: Common input patterns.
+        expected_output_type: Expected type of output.
+        success_rate: Historical success rate (0-1).
+        avg_latency_ms: Average execution time in milliseconds.
+        failure_modes: Known failure modes.
+        usage_count: Total number of uses.
+    """
+
+    id: str = field(default_factory=_uuid)
+    tool_name: str = ""
+    input_pattern: dict[str, Any] = field(default_factory=dict)
+    expected_output_type: str = ""
+    success_rate: float = 0.0
+    avg_latency_ms: float = 0.0
+    failure_modes: list[str] = field(default_factory=list)
+    usage_count: int = 0

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -1,0 +1,276 @@
+"""Tests for core memory models."""
+
+from datetime import timezone
+
+from cognitive_memory.core.memory import (
+    Entity,
+    Fact,
+    Memory,
+    MemorySource,
+    MemoryType,
+    Procedure,
+    Relationship,
+    ScoredMemory,
+    ToolPattern,
+)
+
+
+class TestMemory:
+    """Tests for the Memory dataclass."""
+
+    def test_default_values(self) -> None:
+        """Memory should have sensible defaults."""
+        memory = Memory()
+
+        assert memory.id is not None
+        assert len(memory.id) == 36  # UUID format
+        assert memory.memory_type == MemoryType.EPISODIC
+        assert memory.content == ""
+        assert memory.embedding == []
+        assert memory.metadata == {}
+        assert memory.strength == 1.0
+        assert memory.importance == 0.5
+        assert memory.is_pinned is False
+        assert memory.is_archived is False
+
+    def test_custom_values(self) -> None:
+        """Memory should accept custom values."""
+        memory = Memory(
+            id="test-id",
+            memory_type=MemoryType.SEMANTIC,
+            content="Test content",
+            importance=0.9,
+            is_pinned=True,
+        )
+
+        assert memory.id == "test-id"
+        assert memory.memory_type == MemoryType.SEMANTIC
+        assert memory.content == "Test content"
+        assert memory.importance == 0.9
+        assert memory.is_pinned is True
+
+    def test_timestamps_are_utc(self) -> None:
+        """Timestamps should be in UTC."""
+        memory = Memory()
+
+        assert memory.created_at.tzinfo == timezone.utc
+        assert memory.last_accessed_at.tzinfo == timezone.utc
+
+    def test_memory_types(self) -> None:
+        """All memory types should be valid."""
+        for mem_type in MemoryType:
+            memory = Memory(memory_type=mem_type)
+            assert memory.memory_type == mem_type
+
+    def test_memory_sources(self) -> None:
+        """All memory sources should be valid."""
+        for source in MemorySource:
+            memory = Memory(source=source)
+            assert memory.source == source
+
+
+class TestScoredMemory:
+    """Tests for the ScoredMemory dataclass."""
+
+    def test_default_scores(self) -> None:
+        """ScoredMemory should have zero default scores."""
+        memory = Memory(content="Test")
+        scored = ScoredMemory(memory=memory)
+
+        assert scored.memory == memory
+        assert scored.similarity_score == 0.0
+        assert scored.strength_score == 0.0
+        assert scored.importance_score == 0.0
+        assert scored.recency_score == 0.0
+        assert scored.final_score == 0.0
+
+    def test_custom_scores(self) -> None:
+        """ScoredMemory should accept custom scores."""
+        memory = Memory(content="Test")
+        scored = ScoredMemory(
+            memory=memory,
+            similarity_score=0.8,
+            strength_score=0.9,
+            importance_score=0.7,
+            recency_score=0.6,
+            final_score=0.75,
+        )
+
+        assert scored.similarity_score == 0.8
+        assert scored.strength_score == 0.9
+        assert scored.importance_score == 0.7
+        assert scored.recency_score == 0.6
+        assert scored.final_score == 0.75
+
+
+class TestFact:
+    """Tests for the Fact dataclass."""
+
+    def test_default_values(self) -> None:
+        """Fact should have sensible defaults."""
+        fact = Fact()
+
+        assert fact.id is not None
+        assert fact.subject == ""
+        assert fact.predicate == ""
+        assert fact.object == ""
+        assert fact.confidence == 1.0
+        assert fact.source_memory_ids == []
+        assert fact.verification_count == 1
+
+    def test_as_triple(self) -> None:
+        """Fact should render as a triple string."""
+        fact = Fact(
+            subject="Alice",
+            predicate="works_at",
+            object="Acme Corp",
+        )
+
+        assert fact.as_triple() == "Alice works_at Acme Corp"
+
+    def test_custom_values(self) -> None:
+        """Fact should accept custom values."""
+        fact = Fact(
+            subject="Bob",
+            predicate="knows",
+            object="Python",
+            confidence=0.95,
+            source_memory_ids=["mem-1", "mem-2"],
+        )
+
+        assert fact.subject == "Bob"
+        assert fact.predicate == "knows"
+        assert fact.object == "Python"
+        assert fact.confidence == 0.95
+        assert fact.source_memory_ids == ["mem-1", "mem-2"]
+
+
+class TestEntity:
+    """Tests for the Entity dataclass."""
+
+    def test_default_values(self) -> None:
+        """Entity should have sensible defaults."""
+        entity = Entity()
+
+        assert entity.id is not None
+        assert entity.name == ""
+        assert entity.entity_type == ""
+        assert entity.aliases == []
+        assert entity.attributes == {}
+        assert entity.mention_count == 1
+
+    def test_custom_values(self) -> None:
+        """Entity should accept custom values."""
+        entity = Entity(
+            name="John Doe",
+            entity_type="person",
+            aliases=["JD", "Johnny"],
+            attributes={"role": "engineer"},
+        )
+
+        assert entity.name == "John Doe"
+        assert entity.entity_type == "person"
+        assert entity.aliases == ["JD", "Johnny"]
+        assert entity.attributes["role"] == "engineer"
+
+
+class TestRelationship:
+    """Tests for the Relationship dataclass."""
+
+    def test_default_values(self) -> None:
+        """Relationship should have sensible defaults."""
+        rel = Relationship()
+
+        assert rel.id is not None
+        assert rel.source_entity_id == ""
+        assert rel.target_entity_id == ""
+        assert rel.relationship_type == ""
+        assert rel.properties == {}
+        assert rel.confidence == 1.0
+
+    def test_custom_values(self) -> None:
+        """Relationship should accept custom values."""
+        rel = Relationship(
+            source_entity_id="entity-1",
+            target_entity_id="entity-2",
+            relationship_type="manages",
+            confidence=0.9,
+        )
+
+        assert rel.source_entity_id == "entity-1"
+        assert rel.target_entity_id == "entity-2"
+        assert rel.relationship_type == "manages"
+        assert rel.confidence == 0.9
+
+
+class TestProcedure:
+    """Tests for the Procedure dataclass."""
+
+    def test_default_values(self) -> None:
+        """Procedure should have sensible defaults."""
+        proc = Procedure()
+
+        assert proc.id is not None
+        assert proc.name == ""
+        assert proc.description == ""
+        assert proc.steps == []
+        assert proc.success_count == 0
+        assert proc.failure_count == 0
+        assert proc.last_used is None
+
+    def test_success_rate_no_executions(self) -> None:
+        """Success rate should be 0 with no executions."""
+        proc = Procedure()
+        assert proc.success_rate == 0.0
+
+    def test_success_rate_calculation(self) -> None:
+        """Success rate should be calculated correctly."""
+        proc = Procedure(success_count=8, failure_count=2)
+        assert proc.success_rate == 0.8
+
+    def test_success_rate_all_success(self) -> None:
+        """Success rate should be 1.0 with all successes."""
+        proc = Procedure(success_count=10, failure_count=0)
+        assert proc.success_rate == 1.0
+
+    def test_success_rate_all_failure(self) -> None:
+        """Success rate should be 0.0 with all failures."""
+        proc = Procedure(success_count=0, failure_count=10)
+        assert proc.success_rate == 0.0
+
+
+class TestToolPattern:
+    """Tests for the ToolPattern dataclass."""
+
+    def test_default_values(self) -> None:
+        """ToolPattern should have sensible defaults."""
+        pattern = ToolPattern()
+
+        assert pattern.id is not None
+        assert pattern.tool_name == ""
+        assert pattern.input_pattern == {}
+        assert pattern.expected_output_type == ""
+        assert pattern.success_rate == 0.0
+        assert pattern.avg_latency_ms == 0.0
+        assert pattern.failure_modes == []
+        assert pattern.usage_count == 0
+
+    def test_custom_values(self) -> None:
+        """ToolPattern should accept custom values."""
+        pattern = ToolPattern(
+            tool_name="search",
+            input_pattern={"query": "string"},
+            expected_output_type="list",
+            success_rate=0.95,
+            avg_latency_ms=150.0,
+            failure_modes=["timeout", "rate_limit"],
+            usage_count=100,
+        )
+
+        assert pattern.tool_name == "search"
+        assert pattern.input_pattern == {"query": "string"}
+        assert pattern.expected_output_type == "list"
+        assert pattern.success_rate == 0.95
+        assert pattern.avg_latency_ms == 150.0
+        assert pattern.failure_modes == ["timeout", "rate_limit"]
+        assert pattern.usage_count == 100


### PR DESCRIPTION
## Summary
- Implements core memory data structures: `Memory`, `ScoredMemory`, `Fact`, `Entity`, `Relationship`, `Procedure`, `ToolPattern`
- Adds `MemoryType` and `MemorySource` enums
- Includes comprehensive unit tests (21 tests)

## Test plan
- [x] `make lint` passes
- [x] `make test-unit` passes (23 tests total)
- [x] MyPy type checking passes

Closes #2