### PR TITLE
feat(engines): add DecayEngine with exponential decay and rehearsal

### DIFF
--- a/src/cognitive_memory/engines/__init__.py
+++ b/src/cognitive_memory/engines/__init__.py
@@ -1,0 +1,5 @@
+"""Memory processing engines."""
+
+from cognitive_memory.engines.decay import DecayEngine
+
+__all__ = ["DecayEngine"]

--- a/src/cognitive_memory/engines/decay.py
+++ b/src/cognitive_memory/engines/decay.py
@@ -1,0 +1,339 @@
+"""Decay engine for memory strength calculation."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+# Time unit to seconds conversion
+TIME_UNIT_SECONDS = {
+    "seconds": 1,
+    "minutes": 60,
+    "hours": 3600,
+    "days": 86400,
+}
+
+
+class MemoryProtocol(Protocol):
+    """Protocol for memory objects compatible with DecayEngine."""
+
+    initial_strength: float
+    created_at: datetime
+    last_accessed_at: datetime
+    access_count: int
+    is_pinned: bool
+
+
+class DecayConfigProtocol(Protocol):
+    """Protocol for decay configuration objects."""
+
+    decay_rate: float
+    min_strength: float
+    rehearsal_boost: float
+    rehearsal_decay_rate: float
+    time_unit: str
+
+
+@dataclass
+class DecayResult:
+    """
+    Result of decay calculation.
+
+    Attributes:
+        original_strength: Strength before decay calculation.
+        decayed_strength: Strength after applying decay.
+        time_elapsed: Time elapsed since creation in configured units.
+        rehearsal_bonus: Bonus from rehearsal/access.
+        decay_factor: The exponential decay factor applied.
+    """
+
+    original_strength: float
+    decayed_strength: float
+    time_elapsed: float
+    rehearsal_bonus: float
+    decay_factor: float
+
+
+@dataclass
+class DecayEngine:
+    """
+    Engine for calculating memory decay over time.
+
+    Implements exponential decay with rehearsal effects:
+    strength = initial_strength * e^(-λt) + rehearsal_bonus
+
+    Where:
+    - λ (lambda) is the decay_rate
+    - t is time elapsed in configured units
+    - rehearsal_bonus is accumulated from memory accesses
+
+    The rehearsal bonus itself decays over time, simulating
+    the spacing effect in human memory.
+
+    Attributes:
+        decay_rate: Lambda (λ) in the decay function.
+        min_strength: Floor value for strength.
+        rehearsal_boost: Strength increase per access.
+        rehearsal_decay_rate: How quickly rehearsal bonus fades.
+        time_unit: Unit for time calculations.
+    """
+
+    decay_rate: float = 0.1
+    min_strength: float = 0.01
+    rehearsal_boost: float = 0.2
+    rehearsal_decay_rate: float = 0.05
+    time_unit: str = "hours"
+    _time_unit_seconds: int = field(init=False, repr=False, default=3600)
+
+    def __post_init__(self) -> None:
+        """Initialize computed fields."""
+        self._time_unit_seconds = TIME_UNIT_SECONDS.get(self.time_unit, 3600)
+
+    @classmethod
+    def from_config(cls, config: DecayConfigProtocol) -> DecayEngine:
+        """
+        Create a DecayEngine from configuration.
+
+        Args:
+            config: DecayConfig instance.
+
+        Returns:
+            Configured DecayEngine.
+        """
+        return cls(
+            decay_rate=config.decay_rate,
+            min_strength=config.min_strength,
+            rehearsal_boost=config.rehearsal_boost,
+            rehearsal_decay_rate=config.rehearsal_decay_rate,
+            time_unit=config.time_unit,
+        )
+
+    def calculate_decay(
+        self,
+        memory: MemoryProtocol,
+        current_time: datetime | None = None,
+    ) -> DecayResult:
+        """
+        Calculate the current strength of a memory after decay.
+
+        Args:
+            memory: The memory to calculate decay for.
+            current_time: Time to calculate decay at. Defaults to now.
+
+        Returns:
+            DecayResult with decay calculation details.
+        """
+        if current_time is None:
+            current_time = datetime.now(timezone.utc)
+
+        # Ensure timezone-aware comparison
+        created_at = memory.created_at
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+        if current_time.tzinfo is None:
+            current_time = current_time.replace(tzinfo=timezone.utc)
+
+        # Calculate time elapsed in configured units
+        elapsed_seconds = (current_time - created_at).total_seconds()
+        time_elapsed = elapsed_seconds / self._time_unit_seconds
+
+        # Pinned memories don't decay
+        if memory.is_pinned:
+            return DecayResult(
+                original_strength=memory.initial_strength,
+                decayed_strength=memory.initial_strength,
+                time_elapsed=time_elapsed,
+                rehearsal_bonus=0.0,
+                decay_factor=1.0,
+            )
+
+        # Calculate base exponential decay
+        decay_factor = math.exp(-self.decay_rate * time_elapsed)
+        base_strength = memory.initial_strength * decay_factor
+
+        # Calculate rehearsal bonus (also decays, but slower)
+        # Each access adds rehearsal_boost, which decays at rehearsal_decay_rate
+        rehearsal_bonus = self._calculate_rehearsal_bonus(memory, current_time)
+
+        # Combine and clamp to [min_strength, 1.0]
+        decayed_strength = base_strength + rehearsal_bonus
+        decayed_strength = max(self.min_strength, min(1.0, decayed_strength))
+
+        return DecayResult(
+            original_strength=memory.initial_strength,
+            decayed_strength=decayed_strength,
+            time_elapsed=time_elapsed,
+            rehearsal_bonus=rehearsal_bonus,
+            decay_factor=decay_factor,
+        )
+
+    def _calculate_rehearsal_bonus(
+        self,
+        memory: MemoryProtocol,
+        current_time: datetime,
+    ) -> float:
+        """
+        Calculate the rehearsal bonus from memory accesses.
+
+        Each access adds a boost that decays over time.
+        More recent accesses contribute more.
+
+        Args:
+            memory: The memory to calculate bonus for.
+            current_time: Current time for decay calculation.
+
+        Returns:
+            Total rehearsal bonus.
+        """
+        if memory.access_count == 0:
+            return 0.0
+
+        # Ensure timezone-aware
+        last_accessed = memory.last_accessed_at
+        if last_accessed.tzinfo is None:
+            last_accessed = last_accessed.replace(tzinfo=timezone.utc)
+
+        # Time since last access
+        elapsed_seconds = (current_time - last_accessed).total_seconds()
+        time_since_access = elapsed_seconds / self._time_unit_seconds
+
+        # Rehearsal bonus decays from last access
+        # Scaled by log of access count (diminishing returns)
+        access_multiplier = math.log1p(memory.access_count)
+        base_bonus = self.rehearsal_boost * access_multiplier
+        bonus_decay = math.exp(-self.rehearsal_decay_rate * time_since_access)
+
+        return base_bonus * bonus_decay
+
+    def get_strength(
+        self,
+        memory: MemoryProtocol,
+        current_time: datetime | None = None,
+    ) -> float:
+        """
+        Get the current strength of a memory.
+
+        Convenience method that returns just the strength value.
+
+        Args:
+            memory: The memory to get strength for.
+            current_time: Time to calculate at. Defaults to now.
+
+        Returns:
+            Current memory strength after decay.
+        """
+        result = self.calculate_decay(memory, current_time)
+        return result.decayed_strength
+
+    def apply_rehearsal_in_place(self, memory: Any) -> None:
+        """
+        Apply rehearsal effect to a memory (simulate access).
+
+        Updates the memory's access count and last_accessed_at in place.
+
+        Args:
+            memory: The memory being accessed. Must have mutable
+                access_count and last_accessed_at attributes.
+        """
+        memory.access_count = memory.access_count + 1
+        memory.last_accessed_at = datetime.now(timezone.utc)
+
+    def estimate_time_to_threshold(
+        self,
+        memory: MemoryProtocol,
+        threshold: float,
+        current_time: datetime | None = None,
+    ) -> float | None:
+        """
+        Estimate time until memory strength falls below threshold.
+
+        Useful for scheduling cleanup or consolidation.
+
+        Args:
+            memory: The memory to estimate for.
+            threshold: Strength threshold to reach.
+            current_time: Starting time. Defaults to now.
+
+        Returns:
+            Estimated time in configured units, or None if pinned
+            or already below threshold.
+        """
+        if memory.is_pinned:
+            return None
+
+        if current_time is None:
+            current_time = datetime.now(timezone.utc)
+
+        current_strength = self.get_strength(memory, current_time)
+
+        if current_strength <= threshold:
+            return 0.0
+
+        if memory.initial_strength <= 0 or threshold <= 0:
+            return None
+
+        ratio = threshold / memory.initial_strength
+        if ratio >= 1:
+            return None
+
+        time_to_threshold = -math.log(ratio) / self.decay_rate
+
+        # Subtract time already elapsed
+        created_at = memory.created_at
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+
+        elapsed = (current_time - created_at).total_seconds() / self._time_unit_seconds
+        remaining = time_to_threshold - elapsed
+
+        return max(0.0, remaining)
+
+    def batch_calculate_decay(
+        self,
+        memories: list[MemoryProtocol],
+        current_time: datetime | None = None,
+    ) -> list[tuple[MemoryProtocol, DecayResult]]:
+        """
+        Calculate decay for multiple memories efficiently.
+
+        Args:
+            memories: List of memories to process.
+            current_time: Time to calculate at. Defaults to now.
+
+        Returns:
+            List of (memory, DecayResult) tuples.
+        """
+        if current_time is None:
+            current_time = datetime.now(timezone.utc)
+
+        return [(m, self.calculate_decay(m, current_time)) for m in memories]
+
+    def filter_by_strength(
+        self,
+        memories: list[MemoryProtocol],
+        min_strength: float = 0.0,
+        max_strength: float = 1.0,
+        current_time: datetime | None = None,
+    ) -> list[MemoryProtocol]:
+        """
+        Filter memories by their current strength.
+
+        Args:
+            memories: List of memories to filter.
+            min_strength: Minimum strength (inclusive).
+            max_strength: Maximum strength (inclusive).
+            current_time: Time to calculate at. Defaults to now.
+
+        Returns:
+            Memories with strength in the specified range.
+        """
+        if current_time is None:
+            current_time = datetime.now(timezone.utc)
+
+        return [
+            m
+            for m in memories
+            if min_strength <= self.get_strength(m, current_time) <= max_strength
+        ]

--- a/tests/unit/test_decay.py
+++ b/tests/unit/test_decay.py
@@ -1,0 +1,309 @@
+"""Tests for the decay engine."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from cognitive_memory.engines.decay import DecayEngine, DecayResult
+
+
+# Create minimal Memory-like objects for testing without importing the full module
+class MockMemory:
+    """Mock memory for testing decay engine."""
+
+    def __init__(
+        self,
+        initial_strength: float = 1.0,
+        created_at: datetime | None = None,
+        last_accessed_at: datetime | None = None,
+        access_count: int = 0,
+        is_pinned: bool = False,
+    ):
+        self.initial_strength = initial_strength
+        self.created_at = created_at or datetime.now(timezone.utc)
+        self.last_accessed_at = last_accessed_at or self.created_at
+        self.access_count = access_count
+        self.is_pinned = is_pinned
+
+
+class TestDecayEngine:
+    """Tests for DecayEngine."""
+
+    def test_default_values(self) -> None:
+        """DecayEngine should have sensible defaults."""
+        engine = DecayEngine()
+
+        assert engine.decay_rate == 0.1
+        assert engine.min_strength == 0.01
+        assert engine.rehearsal_boost == 0.2
+        assert engine.time_unit == "hours"
+
+    def test_custom_values(self) -> None:
+        """DecayEngine should accept custom values."""
+        engine = DecayEngine(
+            decay_rate=0.2,
+            min_strength=0.05,
+            rehearsal_boost=0.3,
+            time_unit="days",
+        )
+
+        assert engine.decay_rate == 0.2
+        assert engine.min_strength == 0.05
+        assert engine.rehearsal_boost == 0.3
+        assert engine.time_unit == "days"
+
+
+class TestDecayCalculation:
+    """Tests for decay calculation."""
+
+    def test_no_decay_at_creation(self) -> None:
+        """Memory should have full strength at creation time."""
+        engine = DecayEngine()
+        now = datetime.now(timezone.utc)
+        memory = MockMemory(initial_strength=1.0, created_at=now)
+
+        result = engine.calculate_decay(memory, now)
+
+        assert result.decayed_strength == pytest.approx(1.0, abs=0.01)
+        assert result.time_elapsed == pytest.approx(0.0, abs=0.01)
+
+    def test_decay_over_time(self) -> None:
+        """Memory strength should decrease over time."""
+        engine = DecayEngine(decay_rate=0.1, time_unit="hours")
+        now = datetime.now(timezone.utc)
+        created = now - timedelta(hours=10)
+        memory = MockMemory(initial_strength=1.0, created_at=created)
+
+        result = engine.calculate_decay(memory, now)
+
+        # After 10 hours with λ=0.1: e^(-0.1*10) ≈ 0.368
+        assert result.decayed_strength == pytest.approx(0.368, abs=0.05)
+        assert result.time_elapsed == pytest.approx(10.0, abs=0.1)
+
+    def test_decay_respects_min_strength(self) -> None:
+        """Strength should not fall below min_strength."""
+        engine = DecayEngine(decay_rate=1.0, min_strength=0.1, time_unit="hours")
+        now = datetime.now(timezone.utc)
+        created = now - timedelta(hours=100)
+        memory = MockMemory(initial_strength=1.0, created_at=created)
+
+        result = engine.calculate_decay(memory, now)
+
+        assert result.decayed_strength >= 0.1
+
+    def test_pinned_memory_no_decay(self) -> None:
+        """Pinned memories should not decay."""
+        engine = DecayEngine(decay_rate=1.0, time_unit="hours")
+        now = datetime.now(timezone.utc)
+        created = now - timedelta(hours=100)
+        memory = MockMemory(initial_strength=1.0, created_at=created, is_pinned=True)
+
+        result = engine.calculate_decay(memory, now)
+
+        assert result.decayed_strength == 1.0
+        assert result.decay_factor == 1.0
+
+    def test_decay_result_structure(self) -> None:
+        """DecayResult should contain all expected fields."""
+        engine = DecayEngine()
+        now = datetime.now(timezone.utc)
+        created = now - timedelta(hours=5)
+        memory = MockMemory(initial_strength=0.8, created_at=created)
+
+        result = engine.calculate_decay(memory, now)
+
+        assert isinstance(result, DecayResult)
+        assert result.original_strength == 0.8
+        assert 0 < result.decayed_strength <= 0.8
+        assert result.time_elapsed == pytest.approx(5.0, abs=0.1)
+        assert 0 < result.decay_factor < 1
+
+
+class TestRehearsalEffect:
+    """Tests for rehearsal/access effects."""
+
+    def test_rehearsal_increases_strength(self) -> None:
+        """Accessing a memory should increase its effective strength."""
+        engine = DecayEngine(rehearsal_boost=0.2, time_unit="hours")
+        now = datetime.now(timezone.utc)
+        created = now - timedelta(hours=10)
+
+        # Memory without access
+        memory_no_access = MockMemory(
+            initial_strength=1.0,
+            created_at=created,
+            last_accessed_at=created,
+            access_count=0,
+        )
+
+        # Memory with recent access
+        memory_accessed = MockMemory(
+            initial_strength=1.0,
+            created_at=created,
+            last_accessed_at=now - timedelta(hours=1),
+            access_count=3,
+        )
+
+        result_no_access = engine.calculate_decay(memory_no_access, now)
+        result_accessed = engine.calculate_decay(memory_accessed, now)
+
+        assert result_accessed.decayed_strength > result_no_access.decayed_strength
+        assert result_accessed.rehearsal_bonus > 0
+
+    def test_rehearsal_bonus_decays(self) -> None:
+        """Rehearsal bonus should decay over time since last access."""
+        engine = DecayEngine(rehearsal_boost=0.2, rehearsal_decay_rate=0.1)
+        now = datetime.now(timezone.utc)
+        created = now - timedelta(hours=20)
+
+        # Recent access
+        memory_recent = MockMemory(
+            initial_strength=1.0,
+            created_at=created,
+            last_accessed_at=now - timedelta(hours=1),
+            access_count=5,
+        )
+
+        # Old access
+        memory_old = MockMemory(
+            initial_strength=1.0,
+            created_at=created,
+            last_accessed_at=now - timedelta(hours=10),
+            access_count=5,
+        )
+
+        result_recent = engine.calculate_decay(memory_recent, now)
+        result_old = engine.calculate_decay(memory_old, now)
+
+        assert result_recent.rehearsal_bonus > result_old.rehearsal_bonus
+
+
+class TestGetStrength:
+    """Tests for the get_strength convenience method."""
+
+    def test_get_strength_returns_float(self) -> None:
+        """get_strength should return just the strength value."""
+        engine = DecayEngine()
+        now = datetime.now(timezone.utc)
+        memory = MockMemory(initial_strength=1.0, created_at=now)
+
+        strength = engine.get_strength(memory, now)
+
+        assert isinstance(strength, float)
+        assert 0 <= strength <= 1
+
+    def test_get_strength_matches_calculate_decay(self) -> None:
+        """get_strength should match calculate_decay result."""
+        engine = DecayEngine()
+        now = datetime.now(timezone.utc)
+        created = now - timedelta(hours=5)
+        memory = MockMemory(initial_strength=1.0, created_at=created)
+
+        strength = engine.get_strength(memory, now)
+        result = engine.calculate_decay(memory, now)
+
+        assert strength == result.decayed_strength
+
+
+class TestTimeToThreshold:
+    """Tests for time-to-threshold estimation."""
+
+    def test_estimate_time_to_threshold(self) -> None:
+        """Should estimate time until strength falls below threshold."""
+        engine = DecayEngine(decay_rate=0.1, time_unit="hours")
+        now = datetime.now(timezone.utc)
+        memory = MockMemory(initial_strength=1.0, created_at=now)
+
+        # Time to reach 0.5 strength: t = -ln(0.5) / 0.1 ≈ 6.93 hours
+        time_to_half = engine.estimate_time_to_threshold(memory, 0.5, now)
+
+        assert time_to_half is not None
+        assert time_to_half == pytest.approx(6.93, abs=0.1)
+
+    def test_pinned_memory_returns_none(self) -> None:
+        """Pinned memories should return None (never decay)."""
+        engine = DecayEngine()
+        now = datetime.now(timezone.utc)
+        memory = MockMemory(initial_strength=1.0, created_at=now, is_pinned=True)
+
+        result = engine.estimate_time_to_threshold(memory, 0.5, now)
+
+        assert result is None
+
+    def test_already_below_threshold_returns_zero(self) -> None:
+        """Should return 0 if already below threshold."""
+        engine = DecayEngine(decay_rate=1.0, time_unit="hours")
+        now = datetime.now(timezone.utc)
+        created = now - timedelta(hours=10)
+        memory = MockMemory(initial_strength=1.0, created_at=created)
+
+        result = engine.estimate_time_to_threshold(memory, 0.9, now)
+
+        assert result == 0.0
+
+
+class TestBatchOperations:
+    """Tests for batch operations."""
+
+    def test_batch_calculate_decay(self) -> None:
+        """Should calculate decay for multiple memories."""
+        engine = DecayEngine()
+        now = datetime.now(timezone.utc)
+
+        memories = [
+            MockMemory(initial_strength=1.0, created_at=now - timedelta(hours=i)) for i in range(5)
+        ]
+
+        results = engine.batch_calculate_decay(memories, now)
+
+        assert len(results) == 5
+        for _memory, result in results:
+            assert isinstance(result, DecayResult)
+
+        # Older memories should have lower strength
+        strengths = [r.decayed_strength for _, r in results]
+        assert strengths == sorted(strengths, reverse=True)
+
+    def test_filter_by_strength(self) -> None:
+        """Should filter memories by strength range."""
+        engine = DecayEngine(decay_rate=0.1, time_unit="hours")
+        now = datetime.now(timezone.utc)
+
+        memories = [
+            MockMemory(initial_strength=1.0, created_at=now - timedelta(hours=i * 5))
+            for i in range(10)
+        ]
+
+        # Filter for mid-range strength
+        filtered = engine.filter_by_strength(memories, 0.3, 0.7, now)
+
+        assert len(filtered) > 0
+        for m in filtered:
+            strength = engine.get_strength(m, now)
+            assert 0.3 <= strength <= 0.7
+
+
+class TestTimeUnits:
+    """Tests for different time units."""
+
+    def test_seconds_time_unit(self) -> None:
+        """Should work with seconds time unit."""
+        engine = DecayEngine(decay_rate=0.01, time_unit="seconds")
+        now = datetime.now(timezone.utc)
+        created = now - timedelta(seconds=100)
+        memory = MockMemory(initial_strength=1.0, created_at=created)
+
+        result = engine.calculate_decay(memory, now)
+
+        assert result.time_elapsed == pytest.approx(100.0, abs=1)
+
+    def test_days_time_unit(self) -> None:
+        """Should work with days time unit."""
+        engine = DecayEngine(decay_rate=0.1, time_unit="days")
+        now = datetime.now(timezone.utc)
+        created = now - timedelta(days=7)
+        memory = MockMemory(initial_strength=1.0, created_at=created)
+
+        result = engine.calculate_decay(memory, now)
+
+        assert result.time_elapsed == pytest.approx(7.0, abs=0.1)


### PR DESCRIPTION
## Summary
- Implements `DecayEngine` with exponential decay formula
- Adds rehearsal effect (accessing memories boosts strength)
- Supports configurable time units
- Includes batch operations and filtering by strength
- Uses Protocol types for loose coupling

## Test plan
- [x] `make lint` passes
- [x] `make test-unit` passes (20 tests)
- [x] MyPy type checking passes

Closes #4