### PR TITLE
feat(api): add REST API endpoints

### DIFF
--- a/src/cognitive_memory/api/__init__.py
+++ b/src/cognitive_memory/api/__init__.py
@@ -1,0 +1,5 @@
+"""REST API for cognitive memory."""
+
+from cognitive_memory.api.app import create_app
+
+__all__ = ["create_app"]

--- a/src/cognitive_memory/api/app.py
+++ b/src/cognitive_memory/api/app.py
@@ -1,0 +1,66 @@
+"""FastAPI application factory."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+
+from cognitive_memory import __version__
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(_app: Any) -> AsyncIterator[None]:
+    """Application lifespan manager."""
+    logger.info("Starting cognitive-memory API")
+    yield
+    logger.info("Shutting down cognitive-memory API")
+
+
+def create_app() -> Any:
+    """
+    Create and configure the FastAPI application.
+
+    Returns:
+        Configured FastAPI application instance.
+    """
+    try:
+        from fastapi import FastAPI
+        from fastapi.middleware.cors import CORSMiddleware
+    except ImportError as e:
+        raise ImportError(
+            "FastAPI is required for the REST API. "
+            "Install it with: pip install cognitive-memory[api]"
+        ) from e
+
+    app = FastAPI(
+        title="Cognitive Memory API",
+        description="REST API for agent memory management with intelligent forgetting",
+        version=__version__,
+        lifespan=lifespan,
+        docs_url="/docs",
+        redoc_url="/redoc",
+        openapi_url="/openapi.json",
+    )
+
+    # CORS middleware
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    # Register routes
+    from cognitive_memory.api.routes import health, memories
+
+    app.include_router(health.router, tags=["Health"])
+    app.include_router(memories.router, prefix="/api/v1", tags=["Memories"])
+
+    return app

--- a/src/cognitive_memory/api/models.py
+++ b/src/cognitive_memory/api/models.py
@@ -24,9 +24,7 @@ class MemoryCreate(BaseModel):
     importance: float | None = Field(
         default=None, ge=0.0, le=1.0, description="Explicit importance score"
     )
-    emotional_valence: float = Field(
-        default=0.0, ge=-1.0, le=1.0, description="Emotional valence"
-    )
+    emotional_valence: float = Field(default=0.0, ge=-1.0, le=1.0, description="Emotional valence")
     entities: list[str] = Field(default_factory=list, description="Named entities")
     topics: list[str] = Field(default_factory=list, description="Topics")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Custom metadata")
@@ -36,9 +34,7 @@ class MemoryUpdate(BaseModel):
     """Request model for updating a memory."""
 
     content: str | None = Field(default=None, description="Updated content")
-    importance: float | None = Field(
-        default=None, ge=0.0, le=1.0, description="Updated importance"
-    )
+    importance: float | None = Field(default=None, ge=0.0, le=1.0, description="Updated importance")
     is_pinned: bool | None = Field(default=None, description="Pin status")
     is_archived: bool | None = Field(default=None, description="Archive status")
     entities: list[str] | None = Field(default=None, description="Updated entities")

--- a/src/cognitive_memory/api/models.py
+++ b/src/cognitive_memory/api/models.py
@@ -1,0 +1,125 @@
+"""Pydantic models for API requests and responses."""
+
+from __future__ import annotations
+
+from datetime import datetime  # noqa: TC003
+from typing import Any
+
+try:
+    from pydantic import BaseModel, Field
+except ImportError as e:
+    raise ImportError(
+        "Pydantic is required. Install with: pip install cognitive-memory[api]"
+    ) from e
+
+
+class MemoryCreate(BaseModel):
+    """Request model for creating a memory."""
+
+    content: str = Field(..., description="Memory content text")
+    memory_type: str = Field(default="episodic", description="Type of memory")
+    agent_id: str | None = Field(default=None, description="Agent identifier")
+    user_id: str | None = Field(default=None, description="User identifier")
+    source: str = Field(default="api", description="Memory source")
+    importance: float | None = Field(
+        default=None, ge=0.0, le=1.0, description="Explicit importance score"
+    )
+    emotional_valence: float = Field(
+        default=0.0, ge=-1.0, le=1.0, description="Emotional valence"
+    )
+    entities: list[str] = Field(default_factory=list, description="Named entities")
+    topics: list[str] = Field(default_factory=list, description="Topics")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Custom metadata")
+
+
+class MemoryUpdate(BaseModel):
+    """Request model for updating a memory."""
+
+    content: str | None = Field(default=None, description="Updated content")
+    importance: float | None = Field(
+        default=None, ge=0.0, le=1.0, description="Updated importance"
+    )
+    is_pinned: bool | None = Field(default=None, description="Pin status")
+    is_archived: bool | None = Field(default=None, description="Archive status")
+    entities: list[str] | None = Field(default=None, description="Updated entities")
+    topics: list[str] | None = Field(default=None, description="Updated topics")
+    metadata: dict[str, Any] | None = Field(default=None, description="Updated metadata")
+
+
+class MemoryResponse(BaseModel):
+    """Response model for a memory."""
+
+    id: str = Field(..., description="Memory ID")
+    memory_type: str = Field(..., description="Type of memory")
+    content: str = Field(..., description="Memory content")
+    agent_id: str | None = Field(default=None, description="Agent identifier")
+    user_id: str | None = Field(default=None, description="User identifier")
+    source: str = Field(..., description="Memory source")
+    strength: float = Field(..., description="Current memory strength")
+    importance: float = Field(..., description="Importance score")
+    emotional_valence: float = Field(..., description="Emotional valence")
+    access_count: int = Field(..., description="Number of accesses")
+    entities: list[str] = Field(default_factory=list, description="Named entities")
+    topics: list[str] = Field(default_factory=list, description="Topics")
+    is_pinned: bool = Field(..., description="Whether memory is pinned")
+    is_archived: bool = Field(..., description="Whether memory is archived")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    last_accessed_at: datetime = Field(..., description="Last access timestamp")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Custom metadata")
+
+
+class MemorySearchRequest(BaseModel):
+    """Request model for memory search."""
+
+    query: str = Field(..., description="Search query text")
+    agent_id: str | None = Field(default=None, description="Filter by agent")
+    user_id: str | None = Field(default=None, description="Filter by user")
+    memory_type: str | None = Field(default=None, description="Filter by type")
+    top_k: int = Field(default=10, ge=1, le=100, description="Number of results")
+    use_mmr: bool = Field(default=False, description="Use MMR for diversity")
+    include_archived: bool = Field(default=False, description="Include archived")
+
+
+class MemorySearchResult(BaseModel):
+    """Response model for a search result."""
+
+    memory: MemoryResponse = Field(..., description="The memory")
+    score: float = Field(..., description="Relevance score")
+    similarity: float = Field(..., description="Semantic similarity")
+
+
+class MemorySearchResponse(BaseModel):
+    """Response model for search results."""
+
+    results: list[MemorySearchResult] = Field(..., description="Search results")
+    total: int = Field(..., description="Total results returned")
+    query: str = Field(..., description="Original query")
+
+
+class MemoryListResponse(BaseModel):
+    """Response model for listing memories."""
+
+    memories: list[MemoryResponse] = Field(..., description="List of memories")
+    total: int = Field(..., description="Total count")
+    limit: int = Field(..., description="Limit used")
+    offset: int = Field(..., description="Offset used")
+
+
+class ErrorResponse(BaseModel):
+    """Response model for errors."""
+
+    error: str = Field(..., description="Error type")
+    message: str = Field(..., description="Error message")
+    detail: dict[str, Any] | None = Field(default=None, description="Additional details")
+
+
+class StatsResponse(BaseModel):
+    """Response model for memory statistics."""
+
+    total_memories: int = Field(..., description="Total memory count")
+    by_type: dict[str, int] = Field(..., description="Count by memory type")
+    by_source: dict[str, int] = Field(..., description="Count by source")
+    average_strength: float = Field(..., description="Average memory strength")
+    average_importance: float = Field(..., description="Average importance")
+    pinned_count: int = Field(..., description="Number of pinned memories")
+    archived_count: int = Field(..., description="Number of archived memories")

--- a/src/cognitive_memory/api/routes/__init__.py
+++ b/src/cognitive_memory/api/routes/__init__.py
@@ -1,0 +1,5 @@
+"""API route modules."""
+
+from cognitive_memory.api.routes import health, memories
+
+__all__ = ["health", "memories"]

--- a/src/cognitive_memory/api/routes/health.py
+++ b/src/cognitive_memory/api/routes/health.py
@@ -7,9 +7,7 @@ from typing import Any
 try:
     from fastapi import APIRouter
 except ImportError as e:
-    raise ImportError(
-        "FastAPI is required. Install with: pip install cognitive-memory[api]"
-    ) from e
+    raise ImportError("FastAPI is required. Install with: pip install cognitive-memory[api]") from e
 
 from cognitive_memory import __version__
 

--- a/src/cognitive_memory/api/routes/health.py
+++ b/src/cognitive_memory/api/routes/health.py
@@ -1,0 +1,47 @@
+"""Health check endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from fastapi import APIRouter
+except ImportError as e:
+    raise ImportError(
+        "FastAPI is required. Install with: pip install cognitive-memory[api]"
+    ) from e
+
+from cognitive_memory import __version__
+
+router = APIRouter()
+
+
+@router.get("/health")
+async def health_check() -> dict[str, Any]:
+    """
+    Health check endpoint.
+
+    Returns:
+        Health status and version info.
+    """
+    return {
+        "status": "healthy",
+        "version": __version__,
+        "service": "cognitive-memory",
+    }
+
+
+@router.get("/ready")
+async def readiness_check() -> dict[str, Any]:
+    """
+    Readiness check endpoint.
+
+    Returns:
+        Readiness status.
+    """
+    return {
+        "ready": True,
+        "checks": {
+            "api": True,
+        },
+    }

--- a/src/cognitive_memory/api/routes/memories.py
+++ b/src/cognitive_memory/api/routes/memories.py
@@ -1,0 +1,367 @@
+"""Memory CRUD and search endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+try:
+    from fastapi import APIRouter, HTTPException, Query
+except ImportError as e:
+    raise ImportError(
+        "FastAPI is required. Install with: pip install cognitive-memory[api]"
+    ) from e
+
+from cognitive_memory.api.models import (
+    ErrorResponse,
+    MemoryCreate,
+    MemoryListResponse,
+    MemoryResponse,
+    MemorySearchRequest,
+    MemorySearchResponse,
+    MemorySearchResult,
+    MemoryUpdate,
+    StatsResponse,
+)
+
+router = APIRouter()
+
+# In-memory storage for demo (replace with actual backend in production)
+_memories: dict[str, dict[str, Any]] = {}
+
+
+def _memory_to_response(memory: dict[str, Any]) -> MemoryResponse:
+    """Convert internal memory dict to response model."""
+    return MemoryResponse(
+        id=memory["id"],
+        memory_type=memory.get("memory_type", "episodic"),
+        content=memory.get("content", ""),
+        agent_id=memory.get("agent_id"),
+        user_id=memory.get("user_id"),
+        source=memory.get("source", "api"),
+        strength=memory.get("strength", 1.0),
+        importance=memory.get("importance", 0.5),
+        emotional_valence=memory.get("emotional_valence", 0.0),
+        access_count=memory.get("access_count", 0),
+        entities=memory.get("entities", []),
+        topics=memory.get("topics", []),
+        is_pinned=memory.get("is_pinned", False),
+        is_archived=memory.get("is_archived", False),
+        created_at=memory.get("created_at", datetime.now(timezone.utc)),
+        last_accessed_at=memory.get("last_accessed_at", datetime.now(timezone.utc)),
+        metadata=memory.get("metadata", {}),
+    )
+
+
+@router.post(
+    "/memories",
+    response_model=MemoryResponse,
+    status_code=201,
+    responses={400: {"model": ErrorResponse}},
+)
+async def create_memory(request: MemoryCreate) -> MemoryResponse:
+    """
+    Create a new memory.
+
+    Args:
+        request: Memory creation request.
+
+    Returns:
+        Created memory.
+    """
+    now = datetime.now(timezone.utc)
+    memory_id = str(uuid4())
+
+    memory = {
+        "id": memory_id,
+        "memory_type": request.memory_type,
+        "content": request.content,
+        "agent_id": request.agent_id,
+        "user_id": request.user_id,
+        "source": request.source,
+        "strength": 1.0,
+        "initial_strength": 1.0,
+        "importance": request.importance if request.importance is not None else 0.5,
+        "emotional_valence": request.emotional_valence,
+        "access_count": 0,
+        "entities": request.entities,
+        "topics": request.topics,
+        "is_pinned": False,
+        "is_archived": False,
+        "is_consolidated": False,
+        "created_at": now,
+        "last_accessed_at": now,
+        "metadata": request.metadata,
+    }
+
+    _memories[memory_id] = memory
+    return _memory_to_response(memory)
+
+
+@router.get(
+    "/memories",
+    response_model=MemoryListResponse,
+)
+async def list_memories(
+    agent_id: str | None = Query(default=None, description="Filter by agent"),
+    user_id: str | None = Query(default=None, description="Filter by user"),
+    memory_type: str | None = Query(default=None, description="Filter by type"),
+    is_archived: bool | None = Query(default=None, description="Filter by archived"),
+    limit: int = Query(default=100, ge=1, le=1000, description="Max results"),
+    offset: int = Query(default=0, ge=0, description="Offset for pagination"),
+) -> MemoryListResponse:
+    """
+    List memories with optional filters.
+
+    Args:
+        agent_id: Filter by agent ID.
+        user_id: Filter by user ID.
+        memory_type: Filter by memory type.
+        is_archived: Filter by archived status.
+        limit: Maximum results to return.
+        offset: Pagination offset.
+
+    Returns:
+        List of memories.
+    """
+    filtered = list(_memories.values())
+
+    if agent_id is not None:
+        filtered = [m for m in filtered if m.get("agent_id") == agent_id]
+    if user_id is not None:
+        filtered = [m for m in filtered if m.get("user_id") == user_id]
+    if memory_type is not None:
+        filtered = [m for m in filtered if m.get("memory_type") == memory_type]
+    if is_archived is not None:
+        filtered = [m for m in filtered if m.get("is_archived") == is_archived]
+
+    # Sort by created_at descending
+    filtered.sort(key=lambda m: m.get("created_at", datetime.min), reverse=True)
+
+    total = len(filtered)
+    paginated = filtered[offset : offset + limit]
+
+    return MemoryListResponse(
+        memories=[_memory_to_response(m) for m in paginated],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.post(
+    "/memories/search",
+    response_model=MemorySearchResponse,
+)
+async def search_memories(request: MemorySearchRequest) -> MemorySearchResponse:
+    """
+    Search memories by query.
+
+    Note: This is a simplified text-based search.
+    Production should use vector similarity search.
+
+    Args:
+        request: Search request.
+
+    Returns:
+        Search results.
+    """
+    filtered = list(_memories.values())
+
+    # Apply filters
+    if request.agent_id is not None:
+        filtered = [m for m in filtered if m.get("agent_id") == request.agent_id]
+    if request.user_id is not None:
+        filtered = [m for m in filtered if m.get("user_id") == request.user_id]
+    if request.memory_type is not None:
+        filtered = [m for m in filtered if m.get("memory_type") == request.memory_type]
+    if not request.include_archived:
+        filtered = [m for m in filtered if not m.get("is_archived", False)]
+
+    # Simple text matching (replace with vector search in production)
+    query_lower = request.query.lower()
+    scored = []
+    for memory in filtered:
+        content = memory.get("content", "").lower()
+        if query_lower in content:
+            # Simple relevance score based on position and length
+            pos = content.find(query_lower)
+            score = 1.0 - (pos / max(len(content), 1))
+            scored.append((memory, score))
+
+    # Sort by score
+    scored.sort(key=lambda x: x[1], reverse=True)
+    top_results = scored[: request.top_k]
+
+    results = [
+        MemorySearchResult(
+            memory=_memory_to_response(m),
+            score=s,
+            similarity=s,
+        )
+        for m, s in top_results
+    ]
+
+    return MemorySearchResponse(
+        results=results,
+        total=len(results),
+        query=request.query,
+    )
+
+
+@router.get(
+    "/memories/stats",
+    response_model=StatsResponse,
+)
+async def get_stats(
+    agent_id: str | None = Query(default=None, description="Filter by agent"),
+) -> StatsResponse:
+    """
+    Get memory statistics.
+
+    Args:
+        agent_id: Optional agent filter.
+
+    Returns:
+        Memory statistics.
+    """
+    filtered = list(_memories.values())
+
+    if agent_id is not None:
+        filtered = [m for m in filtered if m.get("agent_id") == agent_id]
+
+    if not filtered:
+        return StatsResponse(
+            total_memories=0,
+            by_type={},
+            by_source={},
+            average_strength=0.0,
+            average_importance=0.0,
+            pinned_count=0,
+            archived_count=0,
+        )
+
+    by_type: dict[str, int] = {}
+    by_source: dict[str, int] = {}
+    total_strength = 0.0
+    total_importance = 0.0
+    pinned_count = 0
+    archived_count = 0
+
+    for memory in filtered:
+        mem_type = memory.get("memory_type", "unknown")
+        by_type[mem_type] = by_type.get(mem_type, 0) + 1
+
+        source = memory.get("source", "unknown")
+        by_source[source] = by_source.get(source, 0) + 1
+
+        total_strength += memory.get("strength", 1.0)
+        total_importance += memory.get("importance", 0.5)
+
+        if memory.get("is_pinned", False):
+            pinned_count += 1
+        if memory.get("is_archived", False):
+            archived_count += 1
+
+    return StatsResponse(
+        total_memories=len(filtered),
+        by_type=by_type,
+        by_source=by_source,
+        average_strength=total_strength / len(filtered),
+        average_importance=total_importance / len(filtered),
+        pinned_count=pinned_count,
+        archived_count=archived_count,
+    )
+
+
+# Routes with path parameters must come after static routes
+@router.get(
+    "/memories/{memory_id}",
+    response_model=MemoryResponse,
+    responses={404: {"model": ErrorResponse}},
+)
+async def get_memory(memory_id: str) -> MemoryResponse:
+    """
+    Get a memory by ID.
+
+    Args:
+        memory_id: Memory identifier.
+
+    Returns:
+        Memory details.
+
+    Raises:
+        HTTPException: If memory not found.
+    """
+    if memory_id not in _memories:
+        raise HTTPException(status_code=404, detail="Memory not found")
+
+    memory = _memories[memory_id]
+    memory["access_count"] += 1
+    memory["last_accessed_at"] = datetime.now(timezone.utc)
+
+    return _memory_to_response(memory)
+
+
+@router.patch(
+    "/memories/{memory_id}",
+    response_model=MemoryResponse,
+    responses={404: {"model": ErrorResponse}},
+)
+async def update_memory(memory_id: str, request: MemoryUpdate) -> MemoryResponse:
+    """
+    Update a memory.
+
+    Args:
+        memory_id: Memory identifier.
+        request: Update request.
+
+    Returns:
+        Updated memory.
+
+    Raises:
+        HTTPException: If memory not found.
+    """
+    if memory_id not in _memories:
+        raise HTTPException(status_code=404, detail="Memory not found")
+
+    memory = _memories[memory_id]
+
+    if request.content is not None:
+        memory["content"] = request.content
+    if request.importance is not None:
+        memory["importance"] = request.importance
+    if request.is_pinned is not None:
+        memory["is_pinned"] = request.is_pinned
+    if request.is_archived is not None:
+        memory["is_archived"] = request.is_archived
+    if request.entities is not None:
+        memory["entities"] = request.entities
+    if request.topics is not None:
+        memory["topics"] = request.topics
+    if request.metadata is not None:
+        memory["metadata"] = request.metadata
+
+    return _memory_to_response(memory)
+
+
+@router.delete(
+    "/memories/{memory_id}",
+    status_code=204,
+    responses={404: {"model": ErrorResponse}},
+)
+async def delete_memory(memory_id: str) -> None:
+    """
+    Delete a memory.
+
+    Args:
+        memory_id: Memory identifier.
+
+    Raises:
+        HTTPException: If memory not found.
+    """
+    if memory_id not in _memories:
+        raise HTTPException(status_code=404, detail="Memory not found")
+
+    del _memories[memory_id]

--- a/src/cognitive_memory/api/routes/memories.py
+++ b/src/cognitive_memory/api/routes/memories.py
@@ -9,9 +9,7 @@ from uuid import uuid4
 try:
     from fastapi import APIRouter, HTTPException, Query
 except ImportError as e:
-    raise ImportError(
-        "FastAPI is required. Install with: pip install cognitive-memory[api]"
-    ) from e
+    raise ImportError("FastAPI is required. Install with: pip install cognitive-memory[api]") from e
 
 from cognitive_memory.api.models import (
     ErrorResponse,

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,0 +1,296 @@
+"""Tests for REST API endpoints."""
+
+import pytest
+
+# Skip all tests if FastAPI not installed
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+from cognitive_memory.api.app import create_app
+from cognitive_memory.api.routes import memories
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Create test client."""
+    app = create_app()
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def clear_memories() -> None:
+    """Clear in-memory storage before each test."""
+    memories._memories.clear()
+
+
+class TestHealthEndpoints:
+    """Tests for health check endpoints."""
+
+    def test_health_check(self, client: TestClient) -> None:
+        """Health endpoint should return healthy status."""
+        response = client.get("/health")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "healthy"
+        assert "version" in data
+
+    def test_readiness_check(self, client: TestClient) -> None:
+        """Readiness endpoint should return ready status."""
+        response = client.get("/ready")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["ready"] is True
+
+
+class TestCreateMemory:
+    """Tests for memory creation."""
+
+    def test_create_memory(self, client: TestClient) -> None:
+        """Should create a memory."""
+        response = client.post(
+            "/api/v1/memories",
+            json={"content": "Test memory content"},
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["content"] == "Test memory content"
+        assert "id" in data
+        assert data["memory_type"] == "episodic"
+
+    def test_create_memory_with_all_fields(self, client: TestClient) -> None:
+        """Should create memory with all fields."""
+        response = client.post(
+            "/api/v1/memories",
+            json={
+                "content": "Full memory",
+                "memory_type": "semantic",
+                "agent_id": "agent-1",
+                "user_id": "user-1",
+                "importance": 0.8,
+                "emotional_valence": 0.5,
+                "entities": ["Alice", "Bob"],
+                "topics": ["work"],
+                "metadata": {"custom": "data"},
+            },
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["memory_type"] == "semantic"
+        assert data["agent_id"] == "agent-1"
+        assert data["importance"] == 0.8
+        assert data["entities"] == ["Alice", "Bob"]
+
+
+class TestGetMemory:
+    """Tests for getting a memory."""
+
+    def test_get_memory(self, client: TestClient) -> None:
+        """Should get a memory by ID."""
+        # Create first
+        create_resp = client.post(
+            "/api/v1/memories",
+            json={"content": "Test content"},
+        )
+        memory_id = create_resp.json()["id"]
+
+        # Get
+        response = client.get(f"/api/v1/memories/{memory_id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == memory_id
+        assert data["access_count"] == 1  # Incremented on access
+
+    def test_get_memory_not_found(self, client: TestClient) -> None:
+        """Should return 404 for nonexistent memory."""
+        response = client.get("/api/v1/memories/nonexistent-id")
+
+        assert response.status_code == 404
+
+
+class TestUpdateMemory:
+    """Tests for updating a memory."""
+
+    def test_update_memory(self, client: TestClient) -> None:
+        """Should update a memory."""
+        # Create first
+        create_resp = client.post(
+            "/api/v1/memories",
+            json={"content": "Original content"},
+        )
+        memory_id = create_resp.json()["id"]
+
+        # Update
+        response = client.patch(
+            f"/api/v1/memories/{memory_id}",
+            json={"content": "Updated content", "is_pinned": True},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["content"] == "Updated content"
+        assert data["is_pinned"] is True
+
+    def test_update_memory_not_found(self, client: TestClient) -> None:
+        """Should return 404 for nonexistent memory."""
+        response = client.patch(
+            "/api/v1/memories/nonexistent-id",
+            json={"content": "New content"},
+        )
+
+        assert response.status_code == 404
+
+
+class TestDeleteMemory:
+    """Tests for deleting a memory."""
+
+    def test_delete_memory(self, client: TestClient) -> None:
+        """Should delete a memory."""
+        # Create first
+        create_resp = client.post(
+            "/api/v1/memories",
+            json={"content": "To be deleted"},
+        )
+        memory_id = create_resp.json()["id"]
+
+        # Delete
+        response = client.delete(f"/api/v1/memories/{memory_id}")
+
+        assert response.status_code == 204
+
+        # Verify deleted
+        get_resp = client.get(f"/api/v1/memories/{memory_id}")
+        assert get_resp.status_code == 404
+
+    def test_delete_memory_not_found(self, client: TestClient) -> None:
+        """Should return 404 for nonexistent memory."""
+        response = client.delete("/api/v1/memories/nonexistent-id")
+
+        assert response.status_code == 404
+
+
+class TestListMemories:
+    """Tests for listing memories."""
+
+    def test_list_memories_empty(self, client: TestClient) -> None:
+        """Should return empty list when no memories."""
+        response = client.get("/api/v1/memories")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["memories"] == []
+        assert data["total"] == 0
+
+    def test_list_memories(self, client: TestClient) -> None:
+        """Should list all memories."""
+        # Create some memories
+        client.post("/api/v1/memories", json={"content": "Memory 1"})
+        client.post("/api/v1/memories", json={"content": "Memory 2"})
+
+        response = client.get("/api/v1/memories")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 2
+        assert len(data["memories"]) == 2
+
+    def test_list_memories_with_filter(self, client: TestClient) -> None:
+        """Should filter memories."""
+        client.post(
+            "/api/v1/memories",
+            json={"content": "Agent 1 memory", "agent_id": "agent-1"},
+        )
+        client.post(
+            "/api/v1/memories",
+            json={"content": "Agent 2 memory", "agent_id": "agent-2"},
+        )
+
+        response = client.get("/api/v1/memories?agent_id=agent-1")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert data["memories"][0]["agent_id"] == "agent-1"
+
+    def test_list_memories_pagination(self, client: TestClient) -> None:
+        """Should paginate results."""
+        for i in range(5):
+            client.post("/api/v1/memories", json={"content": f"Memory {i}"})
+
+        response = client.get("/api/v1/memories?limit=2&offset=2")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 5
+        assert len(data["memories"]) == 2
+        assert data["limit"] == 2
+        assert data["offset"] == 2
+
+
+class TestSearchMemories:
+    """Tests for searching memories."""
+
+    def test_search_memories(self, client: TestClient) -> None:
+        """Should search memories by content."""
+        client.post("/api/v1/memories", json={"content": "The quick brown fox"})
+        client.post("/api/v1/memories", json={"content": "A lazy dog"})
+
+        response = client.post(
+            "/api/v1/memories/search",
+            json={"query": "fox"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert "fox" in data["results"][0]["memory"]["content"]
+
+    def test_search_memories_no_results(self, client: TestClient) -> None:
+        """Should return empty when no matches."""
+        client.post("/api/v1/memories", json={"content": "Some content"})
+
+        response = client.post(
+            "/api/v1/memories/search",
+            json={"query": "nonexistent"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 0
+        assert data["results"] == []
+
+
+class TestStats:
+    """Tests for statistics endpoint."""
+
+    def test_stats_empty(self, client: TestClient) -> None:
+        """Should return zero stats when empty."""
+        response = client.get("/api/v1/memories/stats")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_memories"] == 0
+
+    def test_stats(self, client: TestClient) -> None:
+        """Should return correct statistics."""
+        client.post(
+            "/api/v1/memories",
+            json={"content": "Memory 1", "memory_type": "episodic"},
+        )
+        client.post(
+            "/api/v1/memories",
+            json={"content": "Memory 2", "memory_type": "semantic"},
+        )
+
+        response = client.get("/api/v1/memories/stats")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_memories"] == 2
+        assert data["by_type"]["episodic"] == 1
+        assert data["by_type"]["semantic"] == 1


### PR DESCRIPTION
## Summary
- Implements FastAPI REST API for memory management
- Full CRUD operations with validation
- Listing, search, and statistics endpoints
- Pydantic models for type-safe requests/responses
- Health and readiness checks
- OpenAPI documentation at /docs

## Test plan
- [x] `make lint` passes
- [x] `make test-unit` passes (20 tests)
- [x] MyPy type checking passes

Closes #13