### PR TITLE
feat(storage): add SQLite metadata backend for single-user deployments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ pgvector = [
     "pgvector>=0.2.0",
     "psycopg[binary]>=3.1.0",
 ]
+sqlite = [
+    "aiosqlite>=0.19.0",
+]
 neo4j = [
     "neo4j>=5.0.0",
 ]
@@ -73,7 +76,7 @@ api = [
     "uvicorn[standard]>=0.27.0",
 ]
 all = [
-    "cognitive-memory[qdrant,neo4j,redis,langgraph,langchain,api]",
+    "cognitive-memory[qdrant,neo4j,redis,sqlite,langgraph,langchain,api]",
 ]
 dev = [
     "cognitive-memory[all]",

--- a/src/cognitive_memory/storage/metadata/__init__.py
+++ b/src/cognitive_memory/storage/metadata/__init__.py
@@ -1,5 +1,6 @@
 """Metadata storage backends."""
 
 from cognitive_memory.storage.metadata.postgres import PostgresMetadataBackend
+from cognitive_memory.storage.metadata.sqlite import SQLiteMetadataBackend
 
-__all__ = ["PostgresMetadataBackend"]
+__all__ = ["PostgresMetadataBackend", "SQLiteMetadataBackend"]

--- a/src/cognitive_memory/storage/metadata/sqlite.py
+++ b/src/cognitive_memory/storage/metadata/sqlite.py
@@ -251,7 +251,7 @@ class SQLiteMetadataBackend(MetadataBackend):
         )
         await self._conn.commit()
 
-        return cursor.rowcount > 0
+        return bool(cursor.rowcount and cursor.rowcount > 0)
 
     async def list_memories(
         self,
@@ -349,7 +349,7 @@ class SQLiteMetadataBackend(MetadataBackend):
         )
         await self._conn.commit()
 
-        return cursor.rowcount
+        return int(cursor.rowcount) if cursor.rowcount else 0
 
     async def count(
         self,

--- a/src/cognitive_memory/storage/metadata/sqlite.py
+++ b/src/cognitive_memory/storage/metadata/sqlite.py
@@ -1,0 +1,463 @@
+"""SQLite metadata storage backend for single-user deployments."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from cognitive_memory.storage.metadata.base import MetadataBackend
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SQLiteMetadataBackend(MetadataBackend):
+    """
+    SQLite metadata storage backend.
+
+    Zero-infrastructure alternative to PostgreSQL for single-user
+    or development deployments. Uses aiosqlite for async access
+    and WAL journal mode for safe concurrent reads.
+
+    Attributes:
+        db_path: Path to SQLite database file, or ":memory:" for in-memory.
+        table_name: Name of the memories table.
+    """
+
+    db_path: str = "cognitive_memory.db"
+    table_name: str = "memories"
+    _conn: Any = field(default=None, init=False, repr=False)
+    _initialized: bool = field(default=False, init=False, repr=False)
+
+    async def initialize(self) -> None:
+        """Initialize the database connection and create schema."""
+        if self._initialized:
+            return
+
+        try:
+            import aiosqlite
+        except ImportError as e:
+            raise ImportError(
+                "aiosqlite is required for SQLiteMetadataBackend. "
+                "Install it with: pip install cognitive-memory[sqlite]"
+            ) from e
+
+        self._conn = await aiosqlite.connect(self.db_path)
+        self._conn.row_factory = aiosqlite.Row
+
+        await self._conn.execute("PRAGMA journal_mode=WAL")
+        await self._conn.execute("PRAGMA foreign_keys=ON")
+
+        await self._conn.execute(f"""
+            CREATE TABLE IF NOT EXISTS {self.table_name} (
+                id TEXT PRIMARY KEY,
+                memory_type TEXT NOT NULL DEFAULT 'episodic',
+                content TEXT NOT NULL DEFAULT '',
+                metadata TEXT DEFAULT '{{}}',
+                agent_id TEXT,
+                user_id TEXT,
+                source TEXT DEFAULT 'conversation',
+                source_id TEXT,
+                strength REAL DEFAULT 1.0,
+                initial_strength REAL DEFAULT 1.0,
+                importance REAL DEFAULT 0.5,
+                emotional_valence REAL DEFAULT 0.0,
+                surprise_score REAL DEFAULT 0.0,
+                access_count INTEGER DEFAULT 0,
+                entities TEXT DEFAULT '[]',
+                topics TEXT DEFAULT '[]',
+                related_memory_ids TEXT DEFAULT '[]',
+                parent_memory_id TEXT,
+                superseded_by_id TEXT,
+                is_pinned INTEGER DEFAULT 0,
+                is_archived INTEGER DEFAULT 0,
+                is_consolidated INTEGER DEFAULT 0,
+                created_at TEXT DEFAULT (datetime('now')),
+                last_accessed_at TEXT DEFAULT (datetime('now')),
+                updated_at TEXT DEFAULT (datetime('now'))
+            )
+        """)
+
+        await self._conn.execute(f"""
+            CREATE INDEX IF NOT EXISTS {self.table_name}_agent_id_idx
+            ON {self.table_name} (agent_id)
+        """)
+        await self._conn.execute(f"""
+            CREATE INDEX IF NOT EXISTS {self.table_name}_user_id_idx
+            ON {self.table_name} (user_id)
+        """)
+        await self._conn.execute(f"""
+            CREATE INDEX IF NOT EXISTS {self.table_name}_memory_type_idx
+            ON {self.table_name} (memory_type)
+        """)
+        await self._conn.execute(f"""
+            CREATE INDEX IF NOT EXISTS {self.table_name}_created_at_idx
+            ON {self.table_name} (created_at DESC)
+        """)
+        await self._conn.execute(f"""
+            CREATE INDEX IF NOT EXISTS {self.table_name}_is_archived_idx
+            ON {self.table_name} (is_archived) WHERE is_archived = 0
+        """)
+
+        await self._conn.commit()
+        self._initialized = True
+        logger.info("SQLiteMetadataBackend initialized: %s", self.db_path)
+
+    async def close(self) -> None:
+        """Close the database connection."""
+        if self._conn:
+            await self._conn.close()
+            self._conn = None
+            self._initialized = False
+
+    async def _ensure_initialized(self) -> None:
+        """Ensure the backend is initialized."""
+        if not self._initialized:
+            await self.initialize()
+
+    def _row_to_dict(self, row: Any) -> dict[str, Any]:
+        """Convert a database row to a memory dict."""
+        raw = dict(row)
+        return {
+            "id": raw["id"],
+            "memory_type": raw["memory_type"],
+            "content": raw["content"],
+            "metadata": json.loads(raw["metadata"]) if raw["metadata"] else {},
+            "agent_id": raw["agent_id"],
+            "user_id": raw["user_id"],
+            "source": raw["source"],
+            "source_id": raw["source_id"],
+            "strength": raw["strength"],
+            "initial_strength": raw["initial_strength"],
+            "importance": raw["importance"],
+            "emotional_valence": raw["emotional_valence"],
+            "surprise_score": raw["surprise_score"],
+            "access_count": raw["access_count"],
+            "entities": json.loads(raw["entities"]) if raw["entities"] else [],
+            "topics": json.loads(raw["topics"]) if raw["topics"] else [],
+            "related_memory_ids": (
+                json.loads(raw["related_memory_ids"]) if raw["related_memory_ids"] else []
+            ),
+            "parent_memory_id": raw["parent_memory_id"],
+            "superseded_by_id": raw["superseded_by_id"],
+            "is_pinned": bool(raw["is_pinned"]),
+            "is_archived": bool(raw["is_archived"]),
+            "is_consolidated": bool(raw["is_consolidated"]),
+            "created_at": raw["created_at"],
+            "last_accessed_at": raw["last_accessed_at"],
+            "updated_at": raw["updated_at"],
+        }
+
+    async def save_memory(self, memory: dict[str, Any]) -> None:
+        """Save or update a memory's metadata."""
+        await self._ensure_initialized()
+
+        memory_id = memory.get("id")
+        if not memory_id:
+            raise ValueError("Memory must have an 'id' field")
+
+        now = datetime.now(timezone.utc).isoformat()
+
+        await self._conn.execute(
+            f"""
+            INSERT INTO {self.table_name} (
+                id, memory_type, content, metadata, agent_id, user_id,
+                source, source_id, strength, initial_strength, importance,
+                emotional_valence, surprise_score, access_count,
+                entities, topics, related_memory_ids, parent_memory_id,
+                superseded_by_id, is_pinned, is_archived, is_consolidated,
+                updated_at
+            ) VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            ON CONFLICT(id) DO UPDATE SET
+                memory_type = excluded.memory_type,
+                content = excluded.content,
+                metadata = excluded.metadata,
+                agent_id = excluded.agent_id,
+                user_id = excluded.user_id,
+                source = excluded.source,
+                source_id = excluded.source_id,
+                strength = excluded.strength,
+                initial_strength = excluded.initial_strength,
+                importance = excluded.importance,
+                emotional_valence = excluded.emotional_valence,
+                surprise_score = excluded.surprise_score,
+                access_count = excluded.access_count,
+                entities = excluded.entities,
+                topics = excluded.topics,
+                related_memory_ids = excluded.related_memory_ids,
+                parent_memory_id = excluded.parent_memory_id,
+                superseded_by_id = excluded.superseded_by_id,
+                is_pinned = excluded.is_pinned,
+                is_archived = excluded.is_archived,
+                is_consolidated = excluded.is_consolidated,
+                updated_at = excluded.updated_at
+            """,
+            (
+                memory_id,
+                memory.get("memory_type", "episodic"),
+                memory.get("content", ""),
+                json.dumps(memory.get("metadata", {})),
+                memory.get("agent_id"),
+                memory.get("user_id"),
+                memory.get("source", "conversation"),
+                memory.get("source_id"),
+                memory.get("strength", 1.0),
+                memory.get("initial_strength", 1.0),
+                memory.get("importance", 0.5),
+                memory.get("emotional_valence", 0.0),
+                memory.get("surprise_score", 0.0),
+                memory.get("access_count", 0),
+                json.dumps(memory.get("entities", [])),
+                json.dumps(memory.get("topics", [])),
+                json.dumps(memory.get("related_memory_ids", [])),
+                memory.get("parent_memory_id"),
+                memory.get("superseded_by_id"),
+                int(memory.get("is_pinned", False)),
+                int(memory.get("is_archived", False)),
+                int(memory.get("is_consolidated", False)),
+                now,
+            ),
+        )
+        await self._conn.commit()
+
+    async def get_memory(self, memory_id: str) -> dict[str, Any] | None:
+        """Get a memory by ID."""
+        await self._ensure_initialized()
+
+        cursor = await self._conn.execute(
+            f"SELECT * FROM {self.table_name} WHERE id = ?",
+            (memory_id,),
+        )
+        row = await cursor.fetchone()
+
+        if not row:
+            return None
+
+        return self._row_to_dict(row)
+
+    async def delete_memory(self, memory_id: str) -> bool:
+        """Delete a memory by ID."""
+        await self._ensure_initialized()
+
+        cursor = await self._conn.execute(
+            f"DELETE FROM {self.table_name} WHERE id = ?",
+            (memory_id,),
+        )
+        await self._conn.commit()
+
+        return cursor.rowcount > 0
+
+    async def list_memories(
+        self,
+        agent_id: str | None = None,
+        user_id: str | None = None,
+        memory_type: str | None = None,
+        is_archived: bool | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """List memories with optional filters."""
+        await self._ensure_initialized()
+
+        conditions: list[str] = []
+        params: list[Any] = []
+
+        if agent_id is not None:
+            conditions.append("agent_id = ?")
+            params.append(agent_id)
+        if user_id is not None:
+            conditions.append("user_id = ?")
+            params.append(user_id)
+        if memory_type is not None:
+            conditions.append("memory_type = ?")
+            params.append(memory_type)
+        if is_archived is not None:
+            conditions.append("is_archived = ?")
+            params.append(int(is_archived))
+
+        where_clause = ""
+        if conditions:
+            where_clause = "WHERE " + " AND ".join(conditions)
+
+        params.extend([limit, offset])
+
+        cursor = await self._conn.execute(
+            f"""
+            SELECT * FROM {self.table_name}
+            {where_clause}
+            ORDER BY created_at DESC
+            LIMIT ? OFFSET ?
+            """,
+            params,
+        )
+        rows = await cursor.fetchall()
+
+        return [self._row_to_dict(row) for row in rows]
+
+    async def update_access(
+        self,
+        memory_id: str,
+        accessed_at: datetime | None = None,
+    ) -> None:
+        """Update memory access metadata."""
+        await self._ensure_initialized()
+
+        if accessed_at is None:
+            accessed_at = datetime.now(timezone.utc)
+
+        await self._conn.execute(
+            f"""
+            UPDATE {self.table_name}
+            SET
+                access_count = access_count + 1,
+                last_accessed_at = ?
+            WHERE id = ?
+            """,
+            (accessed_at.isoformat(), memory_id),
+        )
+        await self._conn.commit()
+
+    async def batch_save(self, memories: list[dict[str, Any]]) -> int:
+        """Save multiple memories in a single transaction."""
+        await self._ensure_initialized()
+
+        if not memories:
+            return 0
+
+        for memory in memories:
+            await self.save_memory(memory)
+
+        return len(memories)
+
+    async def batch_delete(self, memory_ids: list[str]) -> int:
+        """Delete multiple memories."""
+        await self._ensure_initialized()
+
+        if not memory_ids:
+            return 0
+
+        placeholders = ",".join("?" for _ in memory_ids)
+        cursor = await self._conn.execute(
+            f"DELETE FROM {self.table_name} WHERE id IN ({placeholders})",
+            memory_ids,
+        )
+        await self._conn.commit()
+
+        return cursor.rowcount
+
+    async def count(
+        self,
+        agent_id: str | None = None,
+        user_id: str | None = None,
+    ) -> int:
+        """Count memories with optional filters."""
+        await self._ensure_initialized()
+
+        conditions: list[str] = []
+        params: list[Any] = []
+
+        if agent_id is not None:
+            conditions.append("agent_id = ?")
+            params.append(agent_id)
+        if user_id is not None:
+            conditions.append("user_id = ?")
+            params.append(user_id)
+
+        where_clause = ""
+        if conditions:
+            where_clause = "WHERE " + " AND ".join(conditions)
+
+        cursor = await self._conn.execute(
+            f"SELECT COUNT(*) FROM {self.table_name} {where_clause}",
+            params,
+        )
+        row = await cursor.fetchone()
+
+        return int(row[0]) if row else 0
+
+    async def get_memories_by_ids(
+        self,
+        memory_ids: list[str],
+    ) -> list[dict[str, Any]]:
+        """Get multiple memories by IDs, preserving input order."""
+        await self._ensure_initialized()
+
+        if not memory_ids:
+            return []
+
+        placeholders = ",".join("?" for _ in memory_ids)
+        cursor = await self._conn.execute(
+            f"SELECT * FROM {self.table_name} WHERE id IN ({placeholders})",
+            memory_ids,
+        )
+        rows = await cursor.fetchall()
+
+        row_dict = {self._row_to_dict(row)["id"]: self._row_to_dict(row) for row in rows}
+        return [row_dict[mid] for mid in memory_ids if mid in row_dict]
+
+    async def search_by_content(
+        self,
+        query: str,
+        agent_id: str | None = None,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        """
+        Simple LIKE-based content search.
+
+        For full-text search, consider FTS5 extension (future enhancement).
+
+        Args:
+            query: Search query string.
+            agent_id: Optional agent filter.
+            limit: Maximum results.
+
+        Returns:
+            Matching memories ordered by creation date.
+        """
+        await self._ensure_initialized()
+
+        params: list[Any] = [f"%{query}%"]
+        agent_filter = ""
+
+        if agent_id:
+            agent_filter = "AND agent_id = ?"
+            params.append(agent_id)
+
+        params.append(limit)
+
+        cursor = await self._conn.execute(
+            f"""
+            SELECT * FROM {self.table_name}
+            WHERE content LIKE ? {agent_filter}
+            ORDER BY created_at DESC
+            LIMIT ?
+            """,
+            params,
+        )
+        rows = await cursor.fetchall()
+
+        return [self._row_to_dict(row) for row in rows]
+
+    async def get_related_memories(
+        self,
+        memory_id: str,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        """Get memories related to a given memory."""
+        await self._ensure_initialized()
+
+        memory = await self.get_memory(memory_id)
+        if not memory:
+            return []
+
+        related_ids = memory.get("related_memory_ids", [])
+        if not related_ids:
+            return []
+
+        return await self.get_memories_by_ids(related_ids[:limit])

--- a/tests/unit/test_sqlite.py
+++ b/tests/unit/test_sqlite.py
@@ -1,0 +1,455 @@
+"""Tests for SQLite metadata backend."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from cognitive_memory.storage.metadata.sqlite import SQLiteMetadataBackend
+
+
+@pytest.fixture
+async def backend():
+    """Create an in-memory SQLite backend for each test."""
+    be = SQLiteMetadataBackend(db_path=":memory:")
+    await be.initialize()
+    yield be
+    await be.close()
+
+
+def _make_memory(
+    memory_id: str = "mem-1",
+    content: str = "Test content",
+    **overrides: object,
+) -> dict:
+    """Helper to build a memory dict with sensible defaults."""
+    base: dict = {
+        "id": memory_id,
+        "memory_type": "episodic",
+        "content": content,
+        "metadata": {"key": "value"},
+        "agent_id": "agent-1",
+        "user_id": "user-1",
+        "source": "conversation",
+        "source_id": None,
+        "strength": 1.0,
+        "initial_strength": 1.0,
+        "importance": 0.5,
+        "emotional_valence": 0.0,
+        "surprise_score": 0.0,
+        "access_count": 0,
+        "entities": ["Alice"],
+        "topics": ["work"],
+        "related_memory_ids": [],
+        "parent_memory_id": None,
+        "superseded_by_id": None,
+        "is_pinned": False,
+        "is_archived": False,
+        "is_consolidated": False,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestSQLiteMetadataBackendInit:
+    """Tests for initialization and lifecycle."""
+
+    def test_default_values(self) -> None:
+        backend = SQLiteMetadataBackend()
+
+        assert backend.db_path == "cognitive_memory.db"
+        assert backend.table_name == "memories"
+
+    def test_custom_values(self) -> None:
+        backend = SQLiteMetadataBackend(db_path="/tmp/test.db", table_name="custom")
+
+        assert backend.db_path == "/tmp/test.db"
+        assert backend.table_name == "custom"
+
+    def test_initial_state(self) -> None:
+        backend = SQLiteMetadataBackend()
+
+        assert backend._conn is None
+        assert backend._initialized is False
+
+    @pytest.mark.asyncio
+    async def test_initialize_creates_table(self) -> None:
+        backend = SQLiteMetadataBackend(db_path=":memory:")
+        await backend.initialize()
+
+        assert backend._initialized is True
+        assert backend._conn is not None
+        await backend.close()
+
+    @pytest.mark.asyncio
+    async def test_double_initialize_is_noop(self) -> None:
+        backend = SQLiteMetadataBackend(db_path=":memory:")
+        await backend.initialize()
+        conn_first = backend._conn
+        await backend.initialize()
+
+        assert backend._conn is conn_first
+        await backend.close()
+
+    @pytest.mark.asyncio
+    async def test_close(self) -> None:
+        backend = SQLiteMetadataBackend(db_path=":memory:")
+        await backend.initialize()
+        await backend.close()
+
+        assert backend._conn is None
+        assert backend._initialized is False
+
+    @pytest.mark.asyncio
+    async def test_close_without_init_is_safe(self) -> None:
+        backend = SQLiteMetadataBackend(db_path=":memory:")
+        await backend.close()
+
+        assert backend._conn is None
+
+
+class TestSQLiteSaveAndGet:
+    """Tests for save_memory and get_memory."""
+
+    @pytest.mark.asyncio
+    async def test_save_and_get(self, backend: SQLiteMetadataBackend) -> None:
+        mem = _make_memory()
+        await backend.save_memory(mem)
+
+        result = await backend.get_memory("mem-1")
+
+        assert result is not None
+        assert result["id"] == "mem-1"
+        assert result["content"] == "Test content"
+        assert result["memory_type"] == "episodic"
+        assert result["metadata"] == {"key": "value"}
+        assert result["entities"] == ["Alice"]
+        assert result["topics"] == ["work"]
+        assert result["agent_id"] == "agent-1"
+        assert result["user_id"] == "user-1"
+        assert result["strength"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent_returns_none(self, backend: SQLiteMetadataBackend) -> None:
+        result = await backend.get_memory("does-not-exist")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_save_without_id_raises(self, backend: SQLiteMetadataBackend) -> None:
+        with pytest.raises(ValueError, match="must have an 'id' field"):
+            await backend.save_memory({"content": "no id"})
+
+    @pytest.mark.asyncio
+    async def test_upsert_updates_existing(self, backend: SQLiteMetadataBackend) -> None:
+        await backend.save_memory(_make_memory(content="version 1"))
+        await backend.save_memory(_make_memory(content="version 2"))
+
+        result = await backend.get_memory("mem-1")
+
+        assert result is not None
+        assert result["content"] == "version 2"
+
+    @pytest.mark.asyncio
+    async def test_save_preserves_boolean_fields(self, backend: SQLiteMetadataBackend) -> None:
+        mem = _make_memory(is_pinned=True, is_archived=True, is_consolidated=True)
+        await backend.save_memory(mem)
+
+        result = await backend.get_memory("mem-1")
+
+        assert result is not None
+        assert result["is_pinned"] is True
+        assert result["is_archived"] is True
+        assert result["is_consolidated"] is True
+
+    @pytest.mark.asyncio
+    async def test_save_with_minimal_fields(self, backend: SQLiteMetadataBackend) -> None:
+        await backend.save_memory({"id": "minimal-1"})
+
+        result = await backend.get_memory("minimal-1")
+
+        assert result is not None
+        assert result["content"] == ""
+        assert result["memory_type"] == "episodic"
+        assert result["strength"] == 1.0
+        assert result["metadata"] == {}
+        assert result["entities"] == []
+
+
+class TestSQLiteDelete:
+    """Tests for delete operations."""
+
+    @pytest.mark.asyncio
+    async def test_delete_existing(self, backend: SQLiteMetadataBackend) -> None:
+        await backend.save_memory(_make_memory())
+
+        result = await backend.delete_memory("mem-1")
+
+        assert result is True
+        assert await backend.get_memory("mem-1") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent(self, backend: SQLiteMetadataBackend) -> None:
+        result = await backend.delete_memory("does-not-exist")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_batch_delete(self, backend: SQLiteMetadataBackend) -> None:
+        for i in range(5):
+            await backend.save_memory(_make_memory(memory_id=f"mem-{i}"))
+
+        deleted = await backend.batch_delete(["mem-0", "mem-1", "mem-2"])
+
+        assert deleted == 3
+        assert await backend.get_memory("mem-0") is None
+        assert await backend.get_memory("mem-3") is not None
+
+    @pytest.mark.asyncio
+    async def test_batch_delete_empty(self, backend: SQLiteMetadataBackend) -> None:
+        assert await backend.batch_delete([]) == 0
+
+    @pytest.mark.asyncio
+    async def test_batch_delete_partial_match(self, backend: SQLiteMetadataBackend) -> None:
+        await backend.save_memory(_make_memory(memory_id="exists"))
+
+        deleted = await backend.batch_delete(["exists", "ghost"])
+
+        assert deleted == 1
+
+
+class TestSQLiteListAndCount:
+    """Tests for list_memories and count."""
+
+    @pytest.mark.asyncio
+    async def test_list_all(self, backend: SQLiteMetadataBackend) -> None:
+        for i in range(3):
+            await backend.save_memory(_make_memory(memory_id=f"mem-{i}"))
+
+        result = await backend.list_memories()
+
+        assert len(result) == 3
+
+    @pytest.mark.asyncio
+    async def test_list_empty(self, backend: SQLiteMetadataBackend) -> None:
+        result = await backend.list_memories()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_agent(self, backend: SQLiteMetadataBackend) -> None:
+        await backend.save_memory(_make_memory(memory_id="a1", agent_id="agent-A"))
+        await backend.save_memory(_make_memory(memory_id="a2", agent_id="agent-A"))
+        await backend.save_memory(_make_memory(memory_id="b1", agent_id="agent-B"))
+
+        result = await backend.list_memories(agent_id="agent-A")
+
+        assert len(result) == 2
+        assert all(m["agent_id"] == "agent-A" for m in result)
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_user(self, backend: SQLiteMetadataBackend) -> None:
+        await backend.save_memory(_make_memory(memory_id="u1", user_id="user-X"))
+        await backend.save_memory(_make_memory(memory_id="u2", user_id="user-Y"))
+
+        result = await backend.list_memories(user_id="user-X")
+
+        assert len(result) == 1
+        assert result[0]["user_id"] == "user-X"
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_type(self, backend: SQLiteMetadataBackend) -> None:
+        await backend.save_memory(_make_memory(memory_id="e1", memory_type="episodic"))
+        await backend.save_memory(_make_memory(memory_id="s1", memory_type="semantic"))
+
+        result = await backend.list_memories(memory_type="semantic")
+
+        assert len(result) == 1
+        assert result[0]["memory_type"] == "semantic"
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_archived(self, backend: SQLiteMetadataBackend) -> None:
+        await backend.save_memory(_make_memory(memory_id="active", is_archived=False))
+        await backend.save_memory(_make_memory(memory_id="archived", is_archived=True))
+
+        result = await backend.list_memories(is_archived=False)
+
+        assert len(result) == 1
+        assert result[0]["id"] == "active"
+
+    @pytest.mark.asyncio
+    async def test_list_with_limit_and_offset(self, backend: SQLiteMetadataBackend) -> None:
+        for i in range(10):
+            await backend.save_memory(_make_memory(memory_id=f"mem-{i:02d}"))
+
+        result = await backend.list_memories(limit=3, offset=0)
+
+        assert len(result) == 3
+
+    @pytest.mark.asyncio
+    async def test_count_all(self, backend: SQLiteMetadataBackend) -> None:
+        for i in range(5):
+            await backend.save_memory(_make_memory(memory_id=f"mem-{i}"))
+
+        assert await backend.count() == 5
+
+    @pytest.mark.asyncio
+    async def test_count_empty(self, backend: SQLiteMetadataBackend) -> None:
+        assert await backend.count() == 0
+
+    @pytest.mark.asyncio
+    async def test_count_with_filters(self, backend: SQLiteMetadataBackend) -> None:
+        await backend.save_memory(_make_memory(memory_id="a1", agent_id="agent-A"))
+        await backend.save_memory(_make_memory(memory_id="a2", agent_id="agent-A"))
+        await backend.save_memory(_make_memory(memory_id="b1", agent_id="agent-B"))
+
+        assert await backend.count(agent_id="agent-A") == 2
+        assert await backend.count(agent_id="agent-B") == 1
+
+
+class TestSQLiteUpdateAccess:
+    """Tests for update_access."""
+
+    @pytest.mark.asyncio
+    async def test_update_access_increments_count(self, backend: SQLiteMetadataBackend) -> None:
+        await backend.save_memory(_make_memory())
+        await backend.update_access("mem-1")
+        await backend.update_access("mem-1")
+
+        result = await backend.get_memory("mem-1")
+
+        assert result is not None
+        assert result["access_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_update_access_with_custom_timestamp(
+        self, backend: SQLiteMetadataBackend
+    ) -> None:
+        await backend.save_memory(_make_memory())
+        ts = datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+        await backend.update_access("mem-1", accessed_at=ts)
+
+        result = await backend.get_memory("mem-1")
+
+        assert result is not None
+        assert result["access_count"] == 1
+        assert "2026-01-15" in result["last_accessed_at"]
+
+
+class TestSQLiteBatchSave:
+    """Tests for batch_save."""
+
+    @pytest.mark.asyncio
+    async def test_batch_save_multiple(self, backend: SQLiteMetadataBackend) -> None:
+        memories = [_make_memory(memory_id=f"mem-{i}") for i in range(5)]
+
+        count = await backend.batch_save(memories)
+
+        assert count == 5
+        assert await backend.count() == 5
+
+    @pytest.mark.asyncio
+    async def test_batch_save_empty(self, backend: SQLiteMetadataBackend) -> None:
+        assert await backend.batch_save([]) == 0
+
+
+class TestSQLiteGetByIds:
+    """Tests for get_memories_by_ids."""
+
+    @pytest.mark.asyncio
+    async def test_get_by_ids(self, backend: SQLiteMetadataBackend) -> None:
+        for i in range(5):
+            await backend.save_memory(_make_memory(memory_id=f"mem-{i}"))
+
+        result = await backend.get_memories_by_ids(["mem-1", "mem-3"])
+
+        assert len(result) == 2
+        assert result[0]["id"] == "mem-1"
+        assert result[1]["id"] == "mem-3"
+
+    @pytest.mark.asyncio
+    async def test_get_by_ids_preserves_order(self, backend: SQLiteMetadataBackend) -> None:
+        for i in range(3):
+            await backend.save_memory(_make_memory(memory_id=f"mem-{i}"))
+
+        result = await backend.get_memories_by_ids(["mem-2", "mem-0", "mem-1"])
+
+        assert [m["id"] for m in result] == ["mem-2", "mem-0", "mem-1"]
+
+    @pytest.mark.asyncio
+    async def test_get_by_ids_empty(self, backend: SQLiteMetadataBackend) -> None:
+        assert await backend.get_memories_by_ids([]) == []
+
+    @pytest.mark.asyncio
+    async def test_get_by_ids_partial_match(self, backend: SQLiteMetadataBackend) -> None:
+        await backend.save_memory(_make_memory(memory_id="exists"))
+
+        result = await backend.get_memories_by_ids(["exists", "ghost"])
+
+        assert len(result) == 1
+        assert result[0]["id"] == "exists"
+
+
+class TestSQLiteSearchByContent:
+    """Tests for search_by_content."""
+
+    @pytest.mark.asyncio
+    async def test_search_finds_match(self, backend: SQLiteMetadataBackend) -> None:
+        await backend.save_memory(_make_memory(memory_id="m1", content="User prefers dark mode"))
+        await backend.save_memory(_make_memory(memory_id="m2", content="Meeting at 3pm"))
+
+        result = await backend.search_by_content("dark mode")
+
+        assert len(result) == 1
+        assert result[0]["id"] == "m1"
+
+    @pytest.mark.asyncio
+    async def test_search_no_match(self, backend: SQLiteMetadataBackend) -> None:
+        await backend.save_memory(_make_memory(content="something else"))
+
+        result = await backend.search_by_content("nonexistent")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_search_with_agent_filter(self, backend: SQLiteMetadataBackend) -> None:
+        await backend.save_memory(
+            _make_memory(memory_id="m1", content="dark mode", agent_id="agent-A")
+        )
+        await backend.save_memory(
+            _make_memory(memory_id="m2", content="dark mode", agent_id="agent-B")
+        )
+
+        result = await backend.search_by_content("dark mode", agent_id="agent-A")
+
+        assert len(result) == 1
+        assert result[0]["agent_id"] == "agent-A"
+
+
+class TestSQLiteGetRelatedMemories:
+    """Tests for get_related_memories."""
+
+    @pytest.mark.asyncio
+    async def test_get_related(self, backend: SQLiteMetadataBackend) -> None:
+        await backend.save_memory(
+            _make_memory(memory_id="parent", related_memory_ids=["child-1", "child-2"])
+        )
+        await backend.save_memory(_make_memory(memory_id="child-1", content="Child 1"))
+        await backend.save_memory(_make_memory(memory_id="child-2", content="Child 2"))
+
+        result = await backend.get_related_memories("parent")
+
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_related_nonexistent_parent(self, backend: SQLiteMetadataBackend) -> None:
+        result = await backend.get_related_memories("ghost")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_get_related_no_relations(self, backend: SQLiteMetadataBackend) -> None:
+        await backend.save_memory(_make_memory(related_memory_ids=[]))
+
+        result = await backend.get_related_memories("mem-1")
+
+        assert result == []


### PR DESCRIPTION
## Summary

Implements `SQLiteMetadataBackend` as a zero-infrastructure alternative to PostgreSQL for single-user or development deployments.

- Extends `MetadataBackend` ABC with full CRUD, batch, search, and filter operations
- Uses `aiosqlite` for async SQLite access with WAL journal mode
- Supports `:memory:` mode for testing (no file I/O)
- Adds `aiosqlite` as optional `[sqlite]` dependency in `pyproject.toml`
- 42 unit tests covering all operations, edge cases, and upsert behavior

## Files Changed

| File | Change |
|------|--------|
| `src/cognitive_memory/storage/metadata/sqlite.py` | New SQLiteMetadataBackend implementation |
| `tests/unit/test_sqlite.py` | 42 unit tests |
| `src/cognitive_memory/storage/metadata/__init__.py` | Export SQLiteMetadataBackend |
| `pyproject.toml` | Add `[sqlite]` optional dependency |

## Test plan

- [x] 42 unit tests pass (all using in-memory SQLite)
- [x] Full test suite (338 tests) passes with no regressions
- [x] Ruff lint + format checks pass
- [x] CRUD: save, get, delete, upsert verified
- [x] Batch operations: batch_save, batch_delete verified
- [x] Filters: agent_id, user_id, memory_type, is_archived verified
- [x] Boolean round-trip (SQLite INTEGER 0/1 → Python bool) verified
- [x] JSON serialization (metadata, entities, topics, related_ids) verified
- [x] Order preservation in get_memories_by_ids verified

Closes #17